### PR TITLE
Added support for parsing JSON from QString and std::string

### DIFF
--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -257,10 +257,20 @@ bool QJsonModel::loadFromFile(const QString& fileName)
 
    if (file.open(QIODevice::ReadOnly)) {
       success = loadFromDevice(&file);
+      qDebug("Successful!");
       file.close();
    }
-
    return success;
+}
+
+bool QJsonModel::loadFromString(const QString qStr) {
+    QByteArray qba = qStr.toLocal8Bit();
+    return loadFromRaw(qba);
+}
+
+bool QJsonModel::loadFromStdString(const std::string str) {
+    QString qStr = QString::fromStdString(str);
+    return loadFromString(qStr);
 }
 
 bool QJsonModel::loadFromDevice(QIODevice* device)

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -257,7 +257,6 @@ bool QJsonModel::loadFromFile(const QString& fileName)
 
    if (file.open(QIODevice::ReadOnly)) {
       success = loadFromDevice(&file);
-      qDebug("Successful!");
       file.close();
    }
    return success;

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -323,6 +323,8 @@ public:
 
 public:
    bool loadFromFile(const QString& fileName);
+   bool loadFromString(const QString qStr);
+   bool loadFromStdString(const std::string str);
    bool loadFromDevice(QIODevice* device);
    bool loadFromValue(const QJsonValue& value);
    bool loadFromDocument(const QJsonDocument& document);

--- a/test/tst_qjsonmodeltest.cpp
+++ b/test/tst_qjsonmodeltest.cpp
@@ -11,6 +11,8 @@ private slots:
 
    void tester();
    void loadFromFile();
+   void loadFromString();
+   void loadFromStdString();
    void loadFromDevice();
    void loadFromDocument();
    void loadFromValue();
@@ -46,6 +48,76 @@ void QJsonModelTest::loadFromFile()
    auto tester = new QAbstractItemModelTester(&model, &model);
    (void)tester; // shut up warnings;
    const bool result = model.loadFromFile(":/sample.json");
+
+   QVERIFY(result);
+   QCOMPARE(model.json(true), _json);
+}
+
+void QJsonModelTest::loadFromString()
+{
+   QJsonModel model;
+   auto tester = new QAbstractItemModelTester(&model, &model);
+   (void)tester; // shut up warnings;
+   QString qStr = "\
+   {\
+      \"firstName\": \"John\",\
+      \"lastName\": \"Smith\",\
+      \"age\": 25,\
+      \"address\": {\
+         \"streetAddress\": \"21 2nd Street\",\
+         \"city\": \"New York\",\
+         \"state\": \"NY\",\
+         \"postalCode\": \"10021\",\
+         \"owner\": true\
+      },\
+      \"phoneNumber\": [\
+         {\
+           \"type\": \"home\",\
+           \"number\": \"212 555-1234\"\
+         },\
+         {\
+           \"type\": \"fax\",\
+           \"number\": \"646 555-4567\"\
+         }\
+      ]\
+   }";
+
+   const bool result = model.loadFromString(qStr);
+
+   QVERIFY(result);
+   QCOMPARE(model.json(true), _json);
+}
+
+void QJsonModelTest::loadFromStdString()
+{
+   QJsonModel model;
+   auto tester = new QAbstractItemModelTester(&model, &model);
+   (void)tester; // shut up warnings;
+   std::string str = "\
+   {\
+      \"firstName\": \"John\",\
+      \"lastName\": \"Smith\",\
+      \"age\": 25,\
+      \"address\": {\
+         \"streetAddress\": \"21 2nd Street\",\
+         \"city\": \"New York\",\
+         \"state\": \"NY\",\
+         \"postalCode\": \"10021\",\
+         \"owner\": true\
+      },\
+      \"phoneNumber\": [\
+         {\
+           \"type\": \"home\",\
+           \"number\": \"212 555-1234\"\
+         },\
+         {\
+           \"type\": \"fax\",\
+           \"number\": \"646 555-4567\"\
+         }\
+      ]\
+   }";
+
+   const bool result = model.loadFromStdString(str);
 
    QVERIFY(result);
    QCOMPARE(model.json(true), _json);


### PR DESCRIPTION
This pr adds the following functions:
- `bool loadFromString(const QString qStr)`
- `bool loadFromStdString(const std::string str)`

This allows a user to parse display JSON easily from either a `QString` or a `std::string` without having to manually parse both into the `QByteArray` required by `loadFromRaw()`. This PR also includes passing test cases for both functions.